### PR TITLE
Add Lazy Hero prototype web app

### DIFF
--- a/lazy_hero.html
+++ b/lazy_hero.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>なまけ勇者 vs 世界を救う重力</title>
+<style>
+ body {
+  margin:0; padding:0; font-family:sans-serif; background:#202830; color:#fff;
+  display:flex; flex-direction:column; height:100vh;
+ }
+ #novelBox {
+  background:#303a44; padding:10px; flex:0 0 auto; display:flex; align-items:center; justify-content:space-between;
+ }
+ #speaker { font-weight:bold; margin-right:10px; }
+ #text { flex:1; }
+ #nextBtn { margin-left:10px; }
+ #gameCanvas { flex:1 1 auto; background:#000; display:none; }
+ #logBox {
+  background:#202020; padding:10px; height:120px; overflow-y:auto; font-size:14px; flex:0 0 auto;
+ }
+ canvas { width:100%; height:100%; }
+</style>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.19.0/matter.min.js"></script>
+</head>
+<body>
+<div id="novelBox">
+ <span id="speaker"></span>
+ <span id="text"></span>
+ <button id="nextBtn">次へ</button>
+</div>
+<canvas id="gameCanvas"></canvas>
+<div id="logBox"></div>
+<script>
+const story = [
+ {speaker:"勇者", text:"今日もベッドが僕を離してくれない…"},
+ {speaker:"魔王兵", text:"勇者よ、覚悟しろ！", eventTrigger:"battle"},
+ {speaker:"勇者", text:"もう終わった？じゃあ寝るね…"}
+];
+let index = 0;
+let state = 'story';
+const speakerEl = document.getElementById('speaker');
+const textEl = document.getElementById('text');
+const nextBtn = document.getElementById('nextBtn');
+const canvas = document.getElementById('gameCanvas');
+const logBox = document.getElementById('logBox');
+let engine, render, enemy;
+
+function showLine() {
+ const line = story[index];
+ speakerEl.textContent = line.speaker;
+ textEl.textContent = line.text;
+ if(line.eventTrigger) {
+  nextBtn.style.display='none';
+  if(line.eventTrigger === 'battle') startBattle();
+ }
+}
+
+nextBtn.addEventListener('click', () => {
+ index++;
+ if(index < story.length) {
+  showLine();
+ } else {
+  speakerEl.textContent = '';
+  textEl.textContent = '終わり';
+  nextBtn.style.display='none';
+ }
+});
+
+function addLog(msg) {
+ const div = document.createElement('div');
+ div.textContent = msg;
+ logBox.appendChild(div);
+ logBox.scrollTop = logBox.scrollHeight;
+}
+
+function startBattle() {
+ state = 'battle';
+ canvas.style.display = 'block';
+ speakerEl.textContent = '';
+ textEl.textContent = '';
+ const width = canvas.clientWidth;
+ const height = canvas.clientHeight;
+ engine = Matter.Engine.create();
+ render = Matter.Render.create({
+  canvas: canvas,
+  engine: engine,
+  options: {
+   width: width,
+   height: height,
+   background:'#111',
+   wireframes:false
+  }
+ });
+ const ground = Matter.Bodies.rectangle(width/2, height-20, width, 40, {isStatic:true});
+ enemy = Matter.Bodies.rectangle(width-60, height-60, 40, 60, {label:'enemy'});
+ const plush = Matter.Bodies.circle(60, height-60, 20, {restitution:0.9, label:'plush'});
+ const orange = Matter.Bodies.circle(140, height-60, 15, {restitution:0.4, label:'orange'});
+ Matter.World.add(engine.world, [ground, enemy, plush, orange]);
+ const mouse = Matter.Mouse.create(canvas);
+ const mouseConstraint = Matter.MouseConstraint.create(engine, { mouse: mouse, constraint: { stiffness:0.2 } });
+ Matter.World.add(engine.world, mouseConstraint);
+ canvas.addEventListener('mouseup',()=>{ setTimeout(()=>{checkBattleEnd();},100); });
+ Matter.Events.on(engine, 'collisionStart', function(event){
+  event.pairs.forEach(pair => {
+   const labels = [pair.bodyA.label, pair.bodyB.label];
+   if(labels.includes('enemy') && labels.includes('plush')) {
+    Matter.World.remove(engine.world, enemy);
+    addLog('対象：魔王兵、ぬいぐるみにより和んで帰った。');
+   }
+   if(labels.includes('enemy') && labels.includes('orange')) {
+    Matter.World.remove(engine.world, enemy);
+    addLog('対象：魔王兵、みかんにより戦意喪失。');
+   }
+  });
+ });
+ Matter.Engine.run(engine);
+ Matter.Render.run(render);
+}
+
+function checkBattleEnd() {
+ if(!engine || !enemy) return;
+ if(engine.world.bodies.indexOf(enemy) === -1) {
+  // enemy removed
+  setTimeout(endBattle, 1000);
+ }
+}
+
+function endBattle() {
+ Matter.Render.stop(render);
+ Matter.World.clear(engine.world);
+ Matter.Engine.clear(engine);
+ canvas.style.display = 'none';
+ nextBtn.style.display = 'inline';
+ state = 'story';
+ index++;
+ if(index < story.length) {
+  showLine();
+ } else {
+  speakerEl.textContent = '';
+  textEl.textContent = '終わり';
+  nextBtn.style.display='none';
+ }
+}
+
+showLine();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `lazy_hero.html` prototype
  - simple novel-style text progression
  - battle scene using Matter.js with draggable plush and orange
  - enemy disappears on hit and log messages appear

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850106393cc833183e8a45c84b531f6