### PR TITLE
Improve Lazy Hero battle with timer and waves

### DIFF
--- a/lazy_hero.html
+++ b/lazy_hero.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>なまけ勇者 vs 世界を救う重力</title>
+<style>
+ body {
+  margin:0; padding:0; font-family:sans-serif; background:#202830; color:#fff;
+  display:flex; flex-direction:column; height:100vh;
+ }
+ #novelBox {
+  background:#303a44; padding:10px; flex:0 0 auto; display:flex; align-items:center; justify-content:space-between;
+ }
+ #speaker { font-weight:bold; margin-right:10px; }
+ #text { flex:1; }
+ #nextBtn { margin-left:10px; }
+#gameCanvas { flex:1 1 auto; background:linear-gradient(#101820,#304050); display:none; }
+#logBox {
+ background:#202020; padding:10px; height:120px; overflow-y:auto; font-size:14px; flex:0 0 auto;
+}
+ canvas { width:100%; height:100%; }
+</style>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.19.0/matter.min.js"></script>
+</head>
+<body>
+<div id="novelBox">
+ <span id="speaker"></span>
+ <span id="text"></span>
+ <button id="nextBtn">次へ</button>
+</div>
+<canvas id="gameCanvas"></canvas>
+<div id="logBox"></div>
+<script>
+const story = [
+ {speaker:"勇者", text:"今日もベッドが僕を離してくれない…"},
+ {speaker:"魔王兵", text:"勇者よ、覚悟しろ！", eventTrigger:"battle"},
+ {speaker:"勇者", text:"もう終わった？じゃあ寝るね…"}
+];
+const states = ["転倒","精神混乱","撤退","冷静さを失う","存在の意味を見失う","自己言及エラー","衝撃吸収失敗"];
+const comments = [
+ "戦意喪失を確認",
+ "ぬくもりにより撤退",
+ "滑り倒し、起き上がらず",
+ "紙詰まりエラーに巻き込まれた可能性",
+ "内省モードへ移行",
+ "感情モジュールが誤作動",
+ "意思決定AIが暴走",
+ "再起動を試みるも失敗",
+ "エネルギー効率が許容範囲を下回る"
+];
+function rand(arr){ return arr[Math.floor(Math.random()*arr.length)]; }
+function generateLog(objName, enemyName){
+ return `対象：${enemyName}、${objName}により${rand(states)}。${rand(comments)}`;
+}
+let index = 0;
+let state = 'story';
+const speakerEl = document.getElementById('speaker');
+const textEl = document.getElementById('text');
+const nextBtn = document.getElementById('nextBtn');
+const canvas = document.getElementById('gameCanvas');
+const logBox = document.getElementById('logBox');
+let engine, render, enemy;
+let wave = 1;
+const maxWaves = 3;
+let timer = 0;
+let timerId;
+let score = 0;
+
+function showLine() {
+ const line = story[index];
+ speakerEl.textContent = line.speaker;
+ textEl.textContent = line.text;
+ if(line.eventTrigger) {
+  nextBtn.style.display='none';
+  if(line.eventTrigger === 'battle') startBattle();
+ }
+}
+
+nextBtn.addEventListener('click', () => {
+ index++;
+ if(index < story.length) {
+  showLine();
+ } else {
+  speakerEl.textContent = '';
+  textEl.textContent = '終わり';
+  nextBtn.style.display='none';
+ }
+});
+
+function addLog(msg) {
+ const div = document.createElement('div');
+ div.textContent = msg;
+ logBox.appendChild(div);
+ while(logBox.children.length > 10) logBox.removeChild(logBox.firstChild);
+ logBox.scrollTop = logBox.scrollHeight;
+}
+
+function startBattle() {
+ state = 'battle';
+ wave = 1;
+ score = 0;
+ startWave();
+}
+
+function startWave() {
+ canvas.style.display = 'block';
+ speakerEl.textContent = '';
+ const width = canvas.clientWidth;
+ const height = canvas.clientHeight;
+ engine = Matter.Engine.create();
+ render = Matter.Render.create({
+  canvas: canvas,
+  engine: engine,
+  options: {
+   width: width,
+   height: height,
+   background: '#111',
+   wireframes: false
+  }
+ });
+ const bodiesToLabel = [];
+ Matter.Events.on(render, 'afterRender', function(){
+  const ctx = render.context;
+  ctx.fillStyle = '#fff';
+  ctx.font = '14px sans-serif';
+  bodiesToLabel.forEach(b => {
+   if(engine.world.bodies.includes(b))
+    ctx.fillText(b.name, b.position.x - 20, b.position.y - 25);
+  });
+ });
+
+ const ground = Matter.Bodies.rectangle(width/2, height-20, width, 40, {isStatic:true, label:'ground'});
+ const ramp = Matter.Bodies.rectangle(width/2, height-80, 200, 20, {isStatic:true, label:'ground', angle:-Math.PI/8});
+ enemy = Matter.Bodies.polygon(width-60, height-60, 5, 30, {label:'enemy'});
+ enemy.name = `魔王兵${wave}`;
+ const plush = Matter.Bodies.circle(60, height-60, 20, {restitution:0.9, label:'plush'});
+ plush.name = 'ぬいぐるみ';
+ const orange = Matter.Bodies.circle(140, height-60, 15, {restitution:0.4, label:'orange'});
+ orange.name = 'みかん';
+ bodiesToLabel.push(enemy, plush, orange);
+ const battleBodies = [ground, ramp, enemy, plush, orange];
+ Matter.World.add(engine.world, battleBodies);
+ const mouse = Matter.Mouse.create(canvas);
+ const mouseConstraint = Matter.MouseConstraint.create(engine, {mouse:mouse, constraint:{stiffness:0.2}});
+ Matter.World.add(engine.world, mouseConstraint);
+
+ Matter.Events.on(engine, 'collisionStart', function(event){
+  event.pairs.forEach(pair => {
+   const pairBodies = [pair.bodyA, pair.bodyB];
+   let obj = pairBodies.find(b => ['plush','orange'].includes(b.label));
+   let foe = pairBodies.find(b => b.label === 'enemy');
+   if(obj && foe) {
+    Matter.World.remove(engine.world, foe);
+    addLog(generateLog(obj.name, foe.name));
+    updateScore(obj.name);
+    spawnNextWave();
+   }
+  });
+ });
+
+ Matter.Engine.run(engine);
+ Matter.Render.run(render);
+ startTimer();
+}
+
+function startTimer() {
+ timer = 30;
+ updateStatus();
+ timerId = setInterval(() => {
+  timer--;
+  updateStatus();
+  if(timer <= 0) {
+   clearInterval(timerId);
+   addLog('時間切れ...');
+   endBattle();
+  }
+ }, 1000);
+}
+
+function updateStatus() {
+ textEl.textContent = `Wave ${wave}/${maxWaves}  Time: ${timer}s  Score: ${score}`;
+}
+
+function updateScore(objName) {
+ score += Math.floor(timer * 5) + (objName === 'ぬいぐるみ' ? 20 : 10);
+}
+
+function spawnNextWave() {
+ clearInterval(timerId);
+ timerId = null;
+ if(wave >= maxWaves) {
+  endBattle();
+  return;
+ }
+ wave++;
+ setTimeout(() => {
+  Matter.Render.stop(render);
+  Matter.World.clear(engine.world);
+  Matter.Engine.clear(engine);
+  startWave();
+ }, 500);
+}
+
+function endBattle() {
+ Matter.Render.stop(render);
+ Matter.World.clear(engine.world);
+ Matter.Engine.clear(engine);
+ canvas.style.display = 'none';
+ nextBtn.style.display = 'inline';
+ state = 'story';
+ addLog(`最終スコア: ${score}`);
+ index++;
+ if(index < story.length) {
+  showLine();
+ } else {
+  speakerEl.textContent = '';
+  textEl.textContent = '終わり';
+  nextBtn.style.display='none';
+ }
+}
+
+showLine();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- fix enemy removal bug by ignoring ground collisions
- add three-wave battle system with per-wave timer
- calculate score based on remaining time and object used
- show status and final score in log
- tweak canvas background for more depth

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850106393cc833183e8a45c84b531f6